### PR TITLE
Link CHANGELOG entries to their tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.1.0 - 2026-07-16
+## [1.1.0] - 2026-07-16
 
 ### Changed
 
@@ -20,10 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `webdrivers` development dependency. Selenium Manager, bundled with
   `selenium-webdriver >= 4.6`, resolves browser drivers instead.
 
-## 1.0.1
+## [1.0.1] - 2024-12-14
 
 - Sequential loading of page objects.
 
-## 1.0.0
+## [1.0.0] - 2024-02-13
 
 - First public release.
+
+[1.1.0]: https://github.com/prism-checker/prism_checker/compare/v1.0.1...v1.1.0
+[1.0.1]: https://github.com/prism-checker/prism_checker/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/prism-checker/prism_checker/releases/tag/v1.0.0


### PR DESCRIPTION
The releases are tagged now, so the compare links resolve. They were left
out when the CHANGELOG was written because no tags existed at the time and
every link would have 404'd.

Release dates come from rubygems. Every link in this diff was checked and
returns 200.

Docs only — no code or CI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)