### PR TITLE
Ignore locally built gems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ coverage/*
 .env
 .byebug_history
 .ruby-version
+
+# Gems built locally by `gem build`
+*.gem


### PR DESCRIPTION
`gem build` drops the packaged `.gem` in the repo root. Those artifacts
were sitting untracked in all three repos — some left over from earlier
releases.

No tracked file matches `*.gem`, so nothing leaves history and no
`git rm --cached` is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)